### PR TITLE
Add namespacing and CUDA streams

### DIFF
--- a/csrc/cuda_rasterizer/preprocess.cu
+++ b/csrc/cuda_rasterizer/preprocess.cu
@@ -456,7 +456,7 @@ void preprocess(int P,
 	float focal_x, float focal_y, float zFar, float zNear,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_unsorted, uint32_t* gaussian_values_unsorted,
-	int* curr_offset)
+	int* curr_offset, cudaStream_t stream)
 {
 	dim3 grid((width + block_x - 1) / block_x, (height + block_y - 1) / block_y, 1);
 
@@ -465,7 +465,7 @@ void preprocess(int P,
 	float tan_fovx = width / (2.0f * focal_x);
 	float tan_fovy = height / (2.0f * focal_y);
 
-	preprocessCUDA<<<(P + 127) / 128, dim3(8, 4, 4)>>>(
+	preprocessCUDA<<<(P + 127) / 128, dim3(8, 4, 4), 0, stream>>>(
 		P,
 		positions,
 		opacities,

--- a/csrc/cuda_rasterizer/preprocess.cu
+++ b/csrc/cuda_rasterizer/preprocess.cu
@@ -7,6 +7,9 @@
 #define GLM_FORCE_CUDA
 #include "../glm/glm.hpp"
 
+namespace flashgs {
+namespace {
+
 constexpr float log2e = 1.4426950216293334961f;
 constexpr float ln2 = 0.69314718055f;
 
@@ -260,7 +263,7 @@ __global__ void preprocessCUDA(
 {
 	int lane = threadIdx.y * blockDim.x + threadIdx.x;
 	int warp_id = blockIdx.x * blockDim.z + threadIdx.z;
-	int idx_vec = warp_id * WARP_SIZE + lane;
+	int idx_vec = warp_id * FLASHGS_WARP_SIZE + lane;
 
 	// Initialize radius and touched tiles to 0. If this isn't changed,
 	// this Gaussian will not be processed further.
@@ -358,7 +361,7 @@ __global__ void preprocessCUDA(
 		};
 		float my_depth = __shfl_sync(~0, p_view.z, i);
 		float my_power = __shfl_sync(~0, power, i);
-		int idx = warp_id * WARP_SIZE + i;
+		int idx = warp_id * FLASHGS_WARP_SIZE + i;
 
 		// For each tile that the bounding rect overlaps, emit a
 		// key/value pair. The key is |  tile ID  |      depth      |,
@@ -444,6 +447,8 @@ glm::mat4 getProjectionMatrix(int width, int height, glm::vec3 position, glm::ma
 	return glm::transpose(P) * getViewMatrix(position, rotation);
 }
 
+} // namespace
+
 void preprocess(int P,
 	glm::vec3* positions, shs_deg3_t* shs, float* opacities, cov3d_t* cov3Ds,
 	int width, int height, int block_x, int block_y,
@@ -481,3 +486,5 @@ void preprocess(int P,
 		gaussian_values_unsorted,
 		grid);
 }
+
+} // namepace flashgs

--- a/csrc/cuda_rasterizer/render.cu
+++ b/csrc/cuda_rasterizer/render.cu
@@ -1,5 +1,8 @@
 #include "../ops.h"
 
+namespace flashgs {
+namespace {
+
 // Check keys to see if it is at the start/end of one tile's range in
 // the full sorted list. If yes, write start/end of this tile.
 // Run once per instanced (duplicated) Gaussian ID.
@@ -71,8 +74,8 @@ __forceinline__ __device__ uint8_t write_color(uchar3* __restrict__ out_color,
 
 struct render_load_info
 {
-	const void* data[WARP_SIZE] = { nullptr };
-	int lg2_scale[WARP_SIZE] = { 0 };
+	const void* data[FLASHGS_WARP_SIZE] = { nullptr };
+	int lg2_scale[FLASHGS_WARP_SIZE] = { 0 };
 
 	render_load_info(const uint32_t* point_list, const float2* points_xy, const float4* rgb_depth, const float4* conic_opacity)
 	{
@@ -572,6 +575,8 @@ void render(int num_rendered,
         out_color);
 }
 
+} // namespace
+
 void render_16x16(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
@@ -601,3 +606,5 @@ void render_32x32(int num_rendered,
     render<32, 32>(num_rendered, width, height, points_xy, rgb_depth, conic_opacity,
 	    gaussian_keys_sorted, gaussian_values_sorted, ranges, bg_color, out_color);
 }
+
+} // namespace flashgs

--- a/csrc/cuda_rasterizer/render.cu
+++ b/csrc/cuda_rasterizer/render.cu
@@ -551,19 +551,19 @@ void render(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
-	int2* ranges, float3 bg_color, uchar3* out_color)
+	int2* ranges, float3 bg_color, uchar3* out_color, cudaStream_t stream)
 {
 	dim3 grid((width + BLOCK_X - 1) / BLOCK_X, (height + BLOCK_Y - 1) / BLOCK_Y, 1);
-	cudaMemsetAsync(ranges, 0, sizeof(int2) * grid.x * grid.y);
+	cudaMemsetAsync(ranges, 0, sizeof(int2) * grid.x * grid.y, stream);
 
     // Identify start and end of per-tile workloads in sorted list
-    identifyTileRanges<<<(num_rendered + 255) / 256, 256>>>(
+    identifyTileRanges<<<(num_rendered + 255) / 256, 256, 0, stream>>>(
         num_rendered,
         gaussian_keys_sorted,
         ranges);
 
     // Let each tile blend its range of Gaussians independently in parallel
-    renderCUDA<BLOCK_X, BLOCK_Y, BLOCK_X / 8, BLOCK_Y / 4><<<grid, dim3(8, 4, 1)>>>(
+    renderCUDA<BLOCK_X, BLOCK_Y, BLOCK_X / 8, BLOCK_Y / 4><<<grid, dim3(8, 4, 1), 0, stream>>>(
         ranges,
         gaussian_values_sorted,
         width, height, grid.x,
@@ -581,30 +581,30 @@ void render_16x16(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
-	int2* ranges, float3 bg_color, uchar3* out_color)
+	int2* ranges, float3 bg_color, uchar3* out_color, cudaStream_t stream)
 {
     render<16, 16>(num_rendered, width, height, points_xy, rgb_depth, conic_opacity,
-	    gaussian_keys_sorted, gaussian_values_sorted, ranges, bg_color, out_color);
+	    gaussian_keys_sorted, gaussian_values_sorted, ranges, bg_color, out_color, stream);
 }
 
 void render_32x16(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
-	int2* ranges, float3 bg_color, uchar3* out_color)
+	int2* ranges, float3 bg_color, uchar3* out_color, cudaStream_t stream)
 {
     render<32, 16>(num_rendered, width, height, points_xy, rgb_depth, conic_opacity,
-	    gaussian_keys_sorted, gaussian_values_sorted, ranges, bg_color, out_color);
+	    gaussian_keys_sorted, gaussian_values_sorted, ranges, bg_color, out_color, stream);
 }
 
 void render_32x32(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
-	int2* ranges, float3 bg_color, uchar3* out_color)
+	int2* ranges, float3 bg_color, uchar3* out_color, cudaStream_t stream)
 {
     render<32, 32>(num_rendered, width, height, points_xy, rgb_depth, conic_opacity,
-	    gaussian_keys_sorted, gaussian_values_sorted, ranges, bg_color, out_color);
+	    gaussian_keys_sorted, gaussian_values_sorted, ranges, bg_color, out_color, stream);
 }
 
 } // namespace flashgs

--- a/csrc/cuda_rasterizer/sort.cu
+++ b/csrc/cuda_rasterizer/sort.cu
@@ -29,27 +29,27 @@ void sort_gaussian(int num_rendered,
     int width, int height, int block_x, int block_y,
 	char* list_sorting_space, size_t sorting_size,
 	uint64_t* gaussian_keys_unsorted, uint32_t* gaussian_values_unsorted,
-	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted)
+	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted, cudaStream_t stream)
 {
 	dim3 grid((width + block_x - 1) / block_x, (height + block_y - 1) / block_y, 1);
 	auto status = cub::DeviceRadixSort::SortPairs(
 		list_sorting_space, sorting_size,
 		gaussian_keys_unsorted, gaussian_keys_sorted,
 		gaussian_values_unsorted, gaussian_values_sorted,
-		num_rendered, 0, 32 + getHigherMsb(grid.x * grid.y));
+		num_rendered, 0, 32 + getHigherMsb(grid.x * grid.y), stream);
     if (status != cudaSuccess)
     {
         throw std::runtime_error(cudaGetErrorString(status));
     }
 }
 
-size_t get_sort_buffer_size(int num_rendered)
+size_t get_sort_buffer_size(int num_rendered, cudaStream_t stream)
 {
     size_t sort_buffer_size = 0;
 	cub::DeviceRadixSort::SortPairs<uint64_t, uint32_t>(
 		nullptr, sort_buffer_size,
 		nullptr, nullptr,
-		nullptr, nullptr, num_rendered);
+		nullptr, nullptr, num_rendered, 0, sizeof(uint64_t) * 8, stream);
     return sort_buffer_size;
 }
 

--- a/csrc/cuda_rasterizer/sort.cu
+++ b/csrc/cuda_rasterizer/sort.cu
@@ -3,6 +3,9 @@
 #include <cub/cub.cuh>
 #include <cub/device/device_radix_sort.cuh>
 
+namespace flashgs {
+namespace {
+
 static uint32_t getHigherMsb(uint32_t n)
 {
 	uint32_t msb = sizeof(n) * 4;
@@ -19,6 +22,8 @@ static uint32_t getHigherMsb(uint32_t n)
 		msb++;
 	return msb;
 }
+
+} // namespace
 
 void sort_gaussian(int num_rendered,
     int width, int height, int block_x, int block_y,
@@ -47,3 +52,5 @@ size_t get_sort_buffer_size(int num_rendered)
 		nullptr, nullptr, num_rendered);
     return sort_buffer_size;
 }
+
+} // namespace flashgs

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -36,32 +36,32 @@ void preprocess(int P,
 	float focal_x, float focal_y, float zFar, float zNear,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_unsorted, uint32_t* gaussian_values_unsorted,
-	int* curr_offset);
+	int* curr_offset, cudaStream_t stream = 0);
 
 void sort_gaussian(int num_rendered,
 	int width, int height, int block_x, int block_y,
 	char* list_sorting_space, size_t sorting_size,
 	uint64_t* gaussian_keys_unsorted, uint32_t* gaussian_values_unsorted,
-	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted);
+	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted, cudaStream_t stream = 0);
 
-size_t get_sort_buffer_size(int num_rendered);
+size_t get_sort_buffer_size(int num_rendered, cudaStream_t stream = 0);
 
 void render_16x16(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
-	int2* ranges, float3 bg_color, uchar3* out_color);
+	int2* ranges, float3 bg_color, uchar3* out_color, cudaStream_t stream = 0);
 
 void render_32x16(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
-	int2* ranges, float3 bg_color, uchar3* out_color);
+	int2* ranges, float3 bg_color, uchar3* out_color, cudaStream_t stream = 0);
 
 void render_32x32(int num_rendered,
 	int width, int height,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
-	int2* ranges, float3 bg_color, uchar3* out_color);
+	int2* ranges, float3 bg_color, uchar3* out_color, cudaStream_t stream = 0);
 
 } // namespace flashgs

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -4,9 +4,9 @@
 #include <stdint.h>
 #include "glm/glm.hpp"
 
-constexpr int WARP_SIZE = 32;
+constexpr int FLASHGS_WARP_SIZE = 32;
 
-#define CHECK_CUDA(x)                                                                   \
+#define FLASHGS_CHECK_CUDA(x)                                                                   \
 	{                                                                                   \
 		cudaError_t status = x;                                                         \
 		if (status != cudaSuccess) {                                                    \
@@ -14,6 +14,8 @@ constexpr int WARP_SIZE = 32;
 			exit(1);                                                                    \
 		}                                                                               \
 	}
+
+namespace flashgs {
 
 union cov3d_t
 {
@@ -61,3 +63,5 @@ void render_32x32(int num_rendered,
 	float2* points_xy, float4* rgb_depth, float4* conic_opacity,
 	uint64_t* gaussian_keys_sorted, uint32_t* gaussian_values_sorted,
 	int2* ranges, float3 bg_color, uchar3* out_color);
+
+} // namespace flashgs

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -6,6 +6,9 @@
 #include <iostream>
 #include <string>
 
+namespace flashgs {
+namespace {
+
 struct VertexStorage
 {
     glm::vec3 position;
@@ -219,42 +222,45 @@ void render_32x32_torch(int num_rendered,
         (uchar3*)out_color.data_ptr());
 }
 
+} // namespace
+} // namespace flashgs
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
     auto ops = m.def_submodule("ops", "my custom operators");
 
     ops.def(
         "loadPly",
-        &loadPly_torch,
+        &flashgs::loadPly_torch,
         "load .ply file and return gaussian model data");
 
     ops.def(
         "preprocess",
-        &preprocess_torch,
+        &flashgs::preprocess_torch,
         "preprocess gaussian model data and generate key-value pairs");
 
     ops.def(
         "sort_gaussian",
-        &sort_gaussian_torch,
+        &flashgs::sort_gaussian_torch,
         "sort gaussian key-value pairs");
 
     ops.def(
         "get_sort_buffer_size",
-        &get_sort_buffer_size,
+        &flashgs::get_sort_buffer_size,
         "get sort buffer size");
 
     ops.def(
         "render_16x16",
-        &render_16x16_torch,
+        &flashgs::render_16x16_torch,
         "sort key-value pairs and render");
 
     ops.def(
         "render_32x16",
-        &render_32x16_torch,
+        &flashgs::render_32x16_torch,
         "sort key-value pairs and render");
 
     ops.def(
         "render_32x32",
-        &render_32x32_torch,
+        &flashgs::render_32x32_torch,
         "sort key-value pairs and render");
 }

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -162,6 +162,11 @@ void sort_gaussian_torch(int num_rendered,
         (uint64_t*)gaussian_keys_sorted.contiguous().data_ptr<int64_t>(), (uint32_t*)gaussian_values_sorted.contiguous().data_ptr<int>());
 }
 
+size_t get_sort_buffer_size_torch(int num_rendered)
+{
+    return get_sort_buffer_size(num_rendered);
+}
+
 void render_16x16_torch(int num_rendered,
 	int width, int height,
 	torch::Tensor& points_xy, torch::Tensor& rgb_depth, torch::Tensor& conic_opacity,
@@ -246,7 +251,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 
     ops.def(
         "get_sort_buffer_size",
-        &flashgs::get_sort_buffer_size,
+        &flashgs::get_sort_buffer_size_torch,
         "get sort buffer size");
 
     ops.def(


### PR DESCRIPTION
Copied from commit messages:

[Add namespacing to functions & constants](https://github.com/InternLandMark/FlashGS/pull/8/commits/08faf2ee53e797d62609db50dee547180d15b4a6) 

All of the current functions are in the top level namespace, which opens
the door for potential naming collisions with other code if / when this
code gets used as a part of a larger project somewhere else. Adding
namespacing makes this substantially more likely.

I've added 2 namespaces, a top level `flashgs` (or `FLASHGS_`) in both
the .h and .cu / .cpp files, as well as an additional anonymous
namespace in the .cu / .cpp files to ensure names of utility functions
don't collide within `flashgs`. The latter is currently unnecessary, but
generally good practice in C++.

[Add support for CUDA streams](https://github.com/InternLandMark/FlashGS/pull/8/commits/784573daf99dde2acadf506fc66e75abba1ca2c1) 

It's good practice to allow users to specify which streams they'd like
to run CUDA kernels on. I've exposed this functionality through the C++
layer, allowing the stream to be specified at the C++ interfaces. The
default is still stream 0 (the default CUDA stream which was being used
before). Python is also still using stream 0 and does not have the API
exposed to use a different stream.